### PR TITLE
repository endpoints can now be updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./main.go --zap-log-level=10
 
 .PHONY: docker-build
 docker-build: #test ## Build docker image with the manager.

--- a/pkg/gateway/reconcile/status.go
+++ b/pkg/gateway/reconcile/status.go
@@ -95,7 +95,8 @@ func GatewayStatus(ctx context.Context, params Params) error {
 		params.Instance.Status = gatewayStatus
 		err = params.Client.Status().Update(ctx, params.Instance)
 		if err != nil {
-			params.Log.Info("failed to update gateway status", "name", params.Instance.Name, "namespace", params.Instance.Namespace, "message", err.Error())
+			params.Log.V(2).Info("failed to update gateway status", "name", params.Instance.Name, "namespace", params.Instance.Namespace, "message", err.Error())
+			return err
 		}
 	}
 	return nil

--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -65,10 +65,22 @@ func CloneRepository(url string, username string, token string, branch string, t
 			return commit.Hash.String(), nil
 		}
 
-		_ = w.Pull(&pullOpts)
-		// if err != nil {
-		// 	return "", err
-		// }
+		gbytes, _ := os.ReadFile("/tmp/" + name + "-" + ext + "/.git/config")
+		if !strings.Contains(string(gbytes), cloneOpts.URL) {
+			err = os.RemoveAll("/tmp/" + name + "-" + ext)
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New("repository endpoint updated, flushing temp storage")
+		}
+
+		err = w.Pull(&pullOpts)
+		if err != nil {
+			if err == git.NoErrAlreadyUpToDate {
+				return commit.Hash.String(), nil
+			}
+			return "", err
+		}
 
 		return commit.Hash.String(), nil
 	}


### PR DESCRIPTION
Addresses an issue where updating an existing repository url (switching from one repo to another or a different vendor) does not trigger an update. 