### PR TITLE
removed auth from repository examples

### DIFF
--- a/example/repositories/apis-repository.yaml
+++ b/example/repositories/apis-repository.yaml
@@ -7,6 +7,6 @@ spec:
   enabled: true
   endpoint: https://github.com/Gazza7205/l7GWMyAPIs
   branch: main
-  auth:
-    vendor: Github
-    existingSecretName: graphman-repository-secret
+  auth: {}
+#    vendor: Github
+#    existingSecretName: graphman-repository-secret

--- a/example/repositories/framework-repository.yaml
+++ b/example/repositories/framework-repository.yaml
@@ -7,6 +7,6 @@ spec:
   enabled: true
   endpoint: https://github.com/Gazza7205/l7GWMyFramework
   branch: main
-  auth:
-    vendor: Github
-    existingSecretName: graphman-repository-secret
+  auth: {}
+#    vendor: Github
+#    existingSecretName: graphman-repository-secret

--- a/example/repositories/subscriptions-repository.yaml
+++ b/example/repositories/subscriptions-repository.yaml
@@ -7,6 +7,6 @@ spec:
   enabled: true
   endpoint: https://github.com/Gazza7205/l7GWMySubscriptions
   branch: main
-  auth:
-    vendor: Github
-    existingSecretName: graphman-repository-secret
+  auth: {}
+#    vendor: Github
+#    existingSecretName: graphman-repository-secret


### PR DESCRIPTION
All of the example repositories are publicly available and do not require authentication. When this repository is made public, the github token will be automatically invalidated.